### PR TITLE
fix: Provide Markdown dimensions for standalone code blocks

### DIFF
--- a/app/src/main/java/com/newoether/agora/ui/chat/message/MessageBubbleAssets.kt
+++ b/app/src/main/java/com/newoether/agora/ui/chat/message/MessageBubbleAssets.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -51,6 +52,7 @@ import com.mikepenz.markdown.model.markdownPadding
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownPadding
 import com.mikepenz.markdown.model.MarkdownTypography
+import com.mikepenz.markdown.model.markdownDimens
 import com.mikepenz.markdown.compose.MarkdownElement
 import com.mikepenz.markdown.compose.components.MarkdownComponents
 import com.mikepenz.markdown.compose.components.MarkdownComponentModel
@@ -405,25 +407,27 @@ internal fun ChatMarkdownCodeBlock(
     modifier: Modifier = Modifier,
 ) {
     val assets = rememberChatMarkdownAssets(MaterialTheme.colorScheme.onSurface)
-    MarkdownCodeBackground(
-        color = assets.renderContext.colors.codeBackground,
-        shape = RoundedCornerShape(LocalMarkdownDimens.current.codeBackgroundCornerSize),
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
-        showHeader = true,
-        language = null,
-        code = code,
-    ) {
-        MarkdownBasicText(
-            text = AnnotatedString(code),
-            style = assets.renderContext.typography.code.copy(
-                color = MaterialTheme.colorScheme.onSurface,
-            ),
-            modifier = Modifier
-                .horizontalScroll(rememberScrollState())
-                .padding(assets.renderContext.padding.codeBlock),
-        )
+    CompositionLocalProvider(LocalMarkdownDimens provides markdownDimens()) {
+        MarkdownCodeBackground(
+            color = assets.renderContext.colors.codeBackground,
+            shape = RoundedCornerShape(LocalMarkdownDimens.current.codeBackgroundCornerSize),
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            showHeader = true,
+            language = null,
+            code = code,
+        ) {
+            MarkdownBasicText(
+                text = AnnotatedString(code),
+                style = assets.renderContext.typography.code.copy(
+                    color = MaterialTheme.colorScheme.onSurface,
+                ),
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .padding(assets.renderContext.padding.codeBlock),
+            )
+        }
     }
 }
 

--- a/app/src/test/java/com/newoether/agora/ui/chat/message/ChatMarkdownCodeBlockSourceContractTest.kt
+++ b/app/src/test/java/com/newoether/agora/ui/chat/message/ChatMarkdownCodeBlockSourceContractTest.kt
@@ -1,0 +1,63 @@
+package com.newoether.agora.ui.chat.message
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatMarkdownCodeBlockSourceContractTest {
+    @Test
+    fun `standalone code block provides markdown dimensions before rendering`() {
+        val source = File(
+            locateMainSourceRoot(),
+            "com/newoether/agora/ui/chat/message/MessageBubbleAssets.kt",
+        ).readText()
+        val body = extractFunctionBody(source, "internal fun ChatMarkdownCodeBlock(")
+        val provider = body.indexOf("LocalMarkdownDimens provides markdownDimens()")
+        val dimensionsRead = body.indexOf("LocalMarkdownDimens.current")
+        val codeBackground = body.indexOf("MarkdownCodeBackground(")
+
+        assertTrue("standalone code blocks must provide default Markdown dimensions", provider >= 0)
+        assertTrue(
+            "Markdown dimensions must be provided before they are read",
+            dimensionsRead >= 0 && provider < dimensionsRead,
+        )
+        assertTrue(
+            "Markdown dimensions must be provided before dimension-dependent elements render",
+            codeBackground >= 0 && provider < codeBackground,
+        )
+        assertFalse("standalone code blocks must not synthesize Markdown", "Markdown(" in body)
+        assertTrue("standalone code blocks must continue rendering raw code", "AnnotatedString(code)" in body)
+    }
+
+    private fun extractFunctionBody(source: String, signature: String): String {
+        val signatureStart = source.indexOf(signature)
+        require(signatureStart >= 0) { "Unable to locate $signature" }
+        val bodyStart = source.indexOf('{', signatureStart)
+        require(bodyStart >= 0) { "Unable to locate body for $signature" }
+
+        var depth = 0
+        for (cursor in bodyStart until source.length) {
+            when (source[cursor]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) return source.substring(bodyStart, cursor + 1)
+                }
+            }
+        }
+        error("Unable to locate closing brace for $signature")
+    }
+
+    private fun locateMainSourceRoot(): File {
+        var directory = File(requireNotNull(System.getProperty("user.dir"))).absoluteFile
+        repeat(8) {
+            listOf(
+                File(directory, "app/src/main/java"),
+                File(directory, "src/main/java"),
+            ).firstOrNull(File::isDirectory)?.let { return it }
+            directory = directory.parentFile ?: error("Reached filesystem root")
+        }
+        error("Unable to locate the main Java source directory")
+    }
+}


### PR DESCRIPTION
Make `ChatMarkdownCodeBlock` honor its standalone contract by installing the markdown library's default dimensions around its production rendering subtree, using the same provider mechanism as the full renderer. Keep the raw-code rendering path, chat colors, typography, padding, and `MarkdownCodeBackground` behavior intact rather than converting shell commands into a synthetic Markdown document or special-casing only the dialog call site. Add a focused source-contract regression test, following the repository's existing JVM source-contract pattern, that isolates the `ChatMarkdownCodeBlock` body and verifies it provides dimensions before reading or rendering dimension-dependent Markdown elements. The remote-shell confirmation dialog renders `pending.summary` through `ChatMarkdownCodeBlock`, and opening that dialog can throw `IllegalStateException: No local MarkdownDimens`. The reusable code-block composable is documented as a standalone surface, but it reads `LocalMarkdownDimens.current` even when no parent `Markdown` renderer has installed that CompositionLocal. The report supplies a concrete stack trace and the existing source confirms the failing access, while another commenter independently reports the crash. No prior or competing pull request is recorded in the supplied issue bundle.

Testing: Opening the shell confirmation dialog with a normal command summary renders the standalone code block without a missing-`MarkdownDimens` exception; A summary containing backticks remains raw code and cannot terminate or alter a synthesized Markdown fence.

Fixes #75
