### PR TITLE
Fix image transcription not reaching target model

### DIFF
--- a/app/src/main/java/com/newoether/agora/viewmodel/GenerationManager.kt
+++ b/app/src/main/java/com/newoether/agora/viewmodel/GenerationManager.kt
@@ -232,7 +232,7 @@ class GenerationManager(
                     conversationId = conversationId,
                     config = config,
                     context = ctx,
-                    loadedMessages = loadedMessages,
+                    loadedMessages = if (transcription.performed) null else loadedMessages,
                 ),
             )
             requestTrace?.mark(


### PR DESCRIPTION
## Summary
Fixes image transcription being generated and persisted, but then omitted from the provider request for the target non-vision model.

## Root cause
`GenerationManager` loads `loadedMessages` before the transcription stage. The transcription stage persists the generated transcription into Room, but `GenerationApiPathBuilder` is then called with that stale pre-transcription snapshot. Because `loadedMessages` is non-null, the builder does not re-read Room, so `ProviderMessageProjector` never sees the newly stored `attachmentMeta.transcription`.

At the same time, successful transcription sets `includeImages = false`, so the target model receives neither the original image nor its transcription.

## Fix
When transcription was performed, do not pass the stale `loadedMessages` snapshot into `GenerationApiPathRequest`. Passing `null` makes `GenerationApiPathBuilder` fetch a fresh durable snapshot containing the stored transcription.

## Reproduction
1. Enable Image Transcription for a non-vision target model.
2. Attach an image and send a prompt asking about its contents.
3. The Image Transcription UI segment shows a correct transcription.
4. The target model behaves as if it received no image information.

The issue reproduced across multiple target models/providers.