### PR TITLE
fix: provide markdown composition locals for standalone code block

### DIFF
--- a/app/src/main/java/com/newoether/agora/ui/chat/message/MessageBubbleAssets.kt
+++ b/app/src/main/java/com/newoether/agora/ui/chat/message/MessageBubbleAssets.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -48,8 +49,10 @@ import com.newoether.agora.ui.theme.ChatType
 import com.mikepenz.markdown.compose.LocalMarkdownColors
 import com.mikepenz.markdown.compose.LocalMarkdownDimens
 import com.mikepenz.markdown.compose.LocalMarkdownPadding
+import com.mikepenz.markdown.compose.LocalMarkdownTypography
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
+import com.mikepenz.markdown.model.markdownDimens
 import com.mikepenz.markdown.model.markdownPadding
 import com.mikepenz.markdown.model.MarkdownColors
 import com.mikepenz.markdown.model.MarkdownPadding
@@ -451,25 +454,36 @@ internal fun ChatMarkdownCodeBlock(
     modifier: Modifier = Modifier,
 ) {
     val assets = rememberChatMarkdownAssets(MaterialTheme.colorScheme.onSurface)
-    MarkdownCodeBackground(
-        color = assets.renderContext.colors.codeBackground,
-        shape = RoundedCornerShape(LocalMarkdownDimens.current.codeBackgroundCornerSize),
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp),
-        showHeader = true,
-        language = null,
-        code = code,
+    // The element components below read composition locals (dimens, colors, typography,
+    // padding) that the Markdown() entry point normally provides. This composable is used
+    // standalone (shell-confirmation dialog), so without the provider the first local read
+    // throws "No local MarkdownDimens".
+    CompositionLocalProvider(
+        LocalMarkdownDimens provides markdownDimens(),
+        LocalMarkdownColors provides assets.renderContext.colors,
+        LocalMarkdownTypography provides assets.renderContext.typography,
+        LocalMarkdownPadding provides assets.renderContext.padding,
     ) {
-        MarkdownBasicText(
-            text = AnnotatedString(code),
-            style = assets.renderContext.typography.code.copy(
-                color = MaterialTheme.colorScheme.onSurface,
-            ),
-            modifier = Modifier
-                .horizontalScroll(rememberScrollState())
-                .padding(assets.renderContext.padding.codeBlock),
-        )
+        MarkdownCodeBackground(
+            color = assets.renderContext.colors.codeBackground,
+            shape = RoundedCornerShape(LocalMarkdownDimens.current.codeBackgroundCornerSize),
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            showHeader = true,
+            language = null,
+            code = code,
+        ) {
+            MarkdownBasicText(
+                text = AnnotatedString(code),
+                style = assets.renderContext.typography.code.copy(
+                    color = MaterialTheme.colorScheme.onSurface,
+                ),
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .padding(assets.renderContext.padding.codeBlock),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
ChatMarkdownCodeBlock renders markdown element components (used by the remote shell command confirmation dialog) outside the Markdown() entry point that normally provides the composition locals. Without them the first local read throws IllegalStateException: No local MarkdownDimens, crashing the app whenever a shell confirmation prompt appears.

Provide LocalMarkdownDimens/Colors/Typography/Padding via CompositionLocalProvider, matching what Markdown() itself provides.